### PR TITLE
adding data attributes to hold zip and date of each individual event

### DIFF
--- a/assets/js/ticketmaster.js
+++ b/assets/js/ticketmaster.js
@@ -37,9 +37,10 @@ var TicketMasterEvent = function() {
             var eventImage = event.images[0].url;
             var venueName = event._embedded.venues["0"].name;
             var eventDate = event.dates.start.localDate;
+            var zip = event._embedded.venues["0"].postalCode;
             html += `
 			        <div class="row">
-			          <div class="col-md-12 event-item">
+			          <div class="col-md-12 event-item" data-zip="${zip}" data-date="${eventDate}">
 			            <div class="col-md-3 float-left">
 			              <img src="${eventImage}">
 			            </div>


### PR DESCRIPTION
This allows each list item event to hold a data attribute of the event date and the zip code of said event.

We do this because if we implement search radius, the ticketmaster api may return to us a number of events from different zip codes.  This also allows us to rely on a data-attribute for the date, instead of relying on the dom element.

(dom elements are more likely to be updated, and if the dom element is taken away for example, the api call wouldn't function as expected.)