### PR TITLE
allowing users to search by city and state as well as zip code

### DIFF
--- a/assets/js/ticketmaster.js
+++ b/assets/js/ticketmaster.js
@@ -7,12 +7,15 @@ var TicketMasterEvent = function() {
      * getEventData passes the response to createEventElements if the ajax call is successful
      * TODO: make getEventData recieve a zip code as a query parameter
      */
-    function getEventData(event, zipCode) {
+    function getEventData(event, city, state, zipCode) {
         var event = event || '';
-        var zipCode = zipCode || 27606;
+        var city = city || '';
+        var state = state || '';
+        var zipCode = zipCode || '';
+
         $.ajax({
             type: "GET",
-            url: `https://app.ticketmaster.com/discovery/v2/events.json?size=10&keyword=${event}&postalCode=${zipCode}&apikey=${apikey}`,
+            url: `https://app.ticketmaster.com/discovery/v2/events.json?size=10&keyword=${event}&city=${city}&state=${state}&postalCode=${zipCode}&apikey=${apikey}`,
             success: function(response) {
                 createEventElements(response);
             },
@@ -71,8 +74,11 @@ var TicketMasterEvent = function() {
         //on click event for the search form passes event and zipcode to ajax function
         $(document).on('click', '#search', function() {
             var event = $('#search-event').val().trim();
+            var city = $('#search-city').val().trim();
+            var state = $('#search-state').val().trim();
             var zip = $('#search-zipcode').val().trim();
-            getEventData(event, zip);
+
+            getEventData(event, city, state, zip);
         });
     }
 

--- a/assets/stylesheets/styles.css
+++ b/assets/stylesheets/styles.css
@@ -122,7 +122,7 @@ section h2 {
 header.masthead {
   color: #fff;
   padding-top: calc(96px + 72px);
-  padding-bottom: 275px;
+  padding-bottom: 425px;
 }
 
 header.masthead h1 {
@@ -138,7 +138,7 @@ header.masthead h2 {
 @media (min-width: 992px) {
   header.masthead {
     padding-top: calc(96px + 106px);
-    padding-bottom: 250px;
+    padding-bottom: 340px;
   }
   header.masthead h1 {
     font-size: 76px;

--- a/index.html
+++ b/index.html
@@ -54,13 +54,15 @@
             <div class="form-group search-form">
               <h6 class="text-left">Search Eventz</h6>
               <input id="search-event" type="text" class="form-control" placeholder="Eventz">
+              <input id="search-city" type="text" class="form-control" placeholder="City">
+              <input id="search-state" type="text" class="form-control" placeholder="State">
               <input id="search-zipcode" type="text" class="form-control" placeholder="Zip Code">
             </div>
             <button id="search" type="submit" class="btn btn-search-submit float-left">Search</button>
           </form>
         </div>
           <div class="col-md-8 float-left">
-            <h4>Eventz is a great way to search for popular events by zip code!</h4>
+            <h4>Eventz is a great way to search for popular events by city, state and or zip code!</h4>
           </div>
       </div>
     </header>


### PR DESCRIPTION
Adding the city and state to the search form will allow for a greater range of events being returned if a specific zip code does not have an event.

The zip code does not need to be entered, each event in the event list has its zip code associated with the event in the data attribute.

Now we can return a variety of events, with different zip codes.