### PR TITLE
fix slick.js init

### DIFF
--- a/assets/js/popular-search.js
+++ b/assets/js/popular-search.js
@@ -5,14 +5,32 @@
  */
 var PopularSearch = function() {
 
-    database.ref('/search').on('value', function(snapshot) {
+    //this reads from the database every time a value in /search is modified/added/removed. We were having issues with this for re-initializing the slick.js carousel. So we choose to read once per page load.
+    // database.ref('/search').on('value', function(snapshot) {
+    //     $('#recent-event-searches').empty();
+    //     $('#popular-event-searches').empty();
+    //     var keys = Object.keys(snapshot.val());
+    //     var mostRecentlySearched = [];
+    //     for (var key in snapshot.val()) {
+    //     	var eventSearched = snapshot.val()[key];
+    //     	mostRecentlySearched.push(eventSearched.event);
+    //     }
+
+    //     displayMostRecentlySearched(mostRecentlySearched);
+    //     displayMostPopularSearched(mostRecentlySearched);
+
+    // }, function(errorObject) {
+    //     console.log('the read failed: ' + errorObject.code);
+    // });
+    //this reads from the database ONCE.
+    database.ref('/search').once('value').then(function(snapshot) {
         $('#recent-event-searches').empty();
         $('#popular-event-searches').empty();
         var keys = Object.keys(snapshot.val());
         var mostRecentlySearched = [];
         for (var key in snapshot.val()) {
-        	var eventSearched = snapshot.val()[key];
-        	mostRecentlySearched.push(eventSearched.event);
+            var eventSearched = snapshot.val()[key];
+            mostRecentlySearched.push(eventSearched.event);
         }
 
         displayMostRecentlySearched(mostRecentlySearched);


### PR DESCRIPTION
slick.js would not re initialize after every search. this fix makes it so we read the values in the database once per page load, so we don't have to re init the slick.js carousel after every search entered.